### PR TITLE
Update to msgraph-beta-sdk==1.29.0

### DIFF
--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,6 +1,5 @@
 {
   "acceptedPythonInterpreters": [
-    "PYTHON38",
     "PYTHON39",
     "PYTHON310",
     "PYTHON311"

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,7 +1,12 @@
 asyncio
-azure-identity==1.17.1
 datetime
-msgraph-core==1.1.0
-msgraph-beta-sdk==1.4.0
-microsoft-kiota-http==1.3.1
 requests
+
+msgraph-beta-sdk==1.29.0
+
+azure-identity==1.21.0
+microsoft-kiota-serialization-form==1.9.3
+microsoft-kiota-serialization-json==1.9.3
+microsoft-kiota-serialization-multipart==1.9.3
+microsoft-kiota-serialization-text==1.9.3
+msgraph-core==1.3.3

--- a/custom-recipes/get-auditlogs/recipe.py
+++ b/custom-recipes/get-auditlogs/recipe.py
@@ -42,11 +42,11 @@ async def getPurviewLogs(credentials, queryStartDate, queryEndDate):
   )
 
   # Send Purview query and get query status
-  queryResult = await msgraph_client.security.audit_log.queries.post(request_body)
+  queryResult = await msgraph_client.security.audit_log.queries.with_url('https://graph.microsoft.com/beta/security/auditLog/queries').post(request_body)
   
   # Wait during query exec
   while True:
-    queryStatus = await msgraph_client.security.audit_log.queries.by_audit_log_query_id(queryResult.id).get()
+    queryStatus = await msgraph_client.security.audit_log.queries.by_audit_log_query_id(queryResult.id).with_url('https://graph.microsoft.com/beta/security/auditLog/queries/' + str(queryResult.id)).get()
     print(queryStatus.status)
     if queryStatus.status == AuditLogQueryStatus.Succeeded:
       break


### PR DESCRIPTION
- Removed Python 3.8 support. Python 3.8 is no longer supported by msgraph-beta-sdk
- msgraph beta URL endpoints explicitly sets as a workaround to the https://github.com/microsoftgraph/msgraph-beta-sdk-python/issues/741 issue

